### PR TITLE
drag fix

### DIFF
--- a/jquery.mb.containerPlus.3.0/inc/jquery.mb.containerPlus.js
+++ b/jquery.mb.containerPlus.3.0/inc/jquery.mb.containerPlus.js
@@ -497,7 +497,8 @@
 				if(!el.fullscreen){
 					if(el.$.data("resize"))
 						el.$.resizable("disable");
-					el.$.draggable("disable");
+					if(el.$.data("drag"))
+						el.$.draggable("disable");
 					el.oWidth= el.$.outerWidth();
 					el.oHeight= el.$.outerHeight();
 					el.oTop= el.$.position().top;


### PR DESCRIPTION
to avoid a "cannot call methods on draggable prior to initialization; attempted to call method 'disable'" error on fullScreen toggle, in case of a non-drag(gable) <div id="cont3" class="container" data-collapse=true data-close=true data-containment="document" data-modal=true> call and latest jQuery and JQuery-UI
